### PR TITLE
Set $identifier if $behavior is KServiceIdentifier

### DIFF
--- a/code/libraries/koowa/database/table/abstract.php
+++ b/code/libraries/koowa/database/table/abstract.php
@@ -279,7 +279,8 @@ abstract class KDatabaseTableAbstract extends KObject
                $identifier->name = $behavior;
            }
            else $identifier = $this->getIdentifier($behavior);
-       }
+       // set the identifier to the behavior
+       } else $identifier = $behavior;
 
        if(!isset($this->getSchema()->behaviors[$identifier->name]))
        {


### PR DESCRIPTION
Was missing a step here. When $behavior enters the method and is a KServiceIdentifier the rest of the method won't use the $behavior or even $identifier at all.
